### PR TITLE
Vma lma

### DIFF
--- a/target.json
+++ b/target.json
@@ -1,5 +1,5 @@
 {
-  "name": "st-stm32f429i-disco-gcc",
+  "name": "stm32f429i-disco-gcc",
   "version": "0.0.2",
   "inherits": {
     "mbed-gcc": "*"


### PR DESCRIPTION
Fix invalid stack & heap pointers
Replace LOADADDR with ADDR to use VMA instead of LMA for RAM-only sections
