### PR TITLE
move uVisor to Core Coupled Memory for decreasing interrupt latency

### DIFF
--- a/ld/STM32F429ZI.ld
+++ b/ld/STM32F429ZI.ld
@@ -53,7 +53,7 @@ SECTIONS
         __uvisor_bss_start = .;
         *(.uvisor.bss*)
         __uvisor_bss_end = .;
-    } > RAM
+    } > CCM
 
     .uvisor.data : AT(__uvisor_cfgtbl_end)
     {
@@ -64,7 +64,7 @@ SECTIONS
         *(.uvisor.data)
         . = ALIGN(32);
         __uvisor_data_end = .;
-    } >RAM
+    } > CCM
 
     .text :
     {


### PR DESCRIPTION
Due to zero wait states I expect more performance on stacking/unstacking operations (SVC calls across box boundaries and interrupts etc.) @AlessandroA @hugovincent @bremoran 
