### PR TITLE
Added config for NVIC definitions

### DIFF
--- a/target.json
+++ b/target.json
@@ -17,17 +17,6 @@
     "stm32f429i-disco",
     "gcc"
   ],
-  "config": {
-    "mbed-os": {},
-    "cmsis": {
-        "nvic": {
-          "ram_vector_address": "0x20000000",
-          "flash_vector_address": "0x08000000",
-          "user_irq_offset": 16,
-          "user_irq_number": 107
-        }
-    }
-  },
   "similarTo": [
     "stm32f429i-disco",
     "f429zi",
@@ -46,6 +35,15 @@
     "gcc"
   ],
   "config": {
+    "mbed-os": {},
+    "cmsis": {
+        "nvic": {
+          "ram_vector_address": "0x20000000",
+          "flash_vector_address": "0x08000000",
+          "user_irq_offset": 16,
+          "user_irq_number": 107
+        }
+    },
     "hardware": {
       "externalClock": "8000000"
     }

--- a/target.json
+++ b/target.json
@@ -17,6 +17,17 @@
     "stm32f429i-disco",
     "gcc"
   ],
+  "config": {
+    "mbed-os": {},
+    "cmsis": {
+        "nvic": {
+          "ram_vector_address": "0x20000000",
+          "flash_vector_address": "0x08000000",
+          "user_irq_offset": 16,
+          "user_irq_number": 107
+        }
+    }
+  },
   "similarTo": [
     "stm32f429i-disco",
     "f429zi",


### PR DESCRIPTION
This PR adds config entries for the following definitions:
```C
NVIC_NUM_VECTORS
NVIC_USER_IRQ_OFFSET
NVIC_RAM_VECTOR_ADDRESS
NVIC_FLASH_VECTOR_ADDRESS
```

when these changes are merged, the related PRs can be merged, so that `cmsis_nvic.*` files are moved from hw-specific `cmsis-core-*` modules to `cmsis-core`, to avoid duplication