### PR TITLE
Added missing symbols for backward compatibility

### DIFF
--- a/ld/STM32F429ZI.ld
+++ b/ld/STM32F429ZI.ld
@@ -208,6 +208,16 @@ SECTIONS
         KEEP(*(.keep.uvisor.cfgtbl_ptr))
         __uvisor_cfgtbl_ptr_end = .;
 
+        /* the following symbols are kept for backward compatibility and will be soon
+         * deprecated; applications actively using uVisor (__uvisor_mode == UVISOR_ENABLED)
+         * will need to use uVisor 0.8.x or above, or the security assertions will halt the
+         * system */
+        /************************/
+        __uvisor_data_src = .;
+        __uvisor_data_start = .;
+        __uvisor_data_end = .;
+        /************************/
+
         . = ALIGN(32);
         __uvisor_secure_end = .;
     } >FLASH


### PR DESCRIPTION
The symbols are kept so that applications built on top of `uvisor-lib` 0.7.x or below
can still compile and link successfully. Those applications will not be able to
enable uVisor though, as security assertions will fail. This is fixed from `uvisor-lib` 0.8.x