### PR TITLE
Add linker script section for uninitialized data

### DIFF
--- a/ld/STM32F429ZI.ld
+++ b/ld/STM32F429ZI.ld
@@ -222,6 +222,16 @@ SECTIONS
         __uvisor_secure_end = .;
     } >FLASH
 
+    .uninitialized (NOLOAD):
+    {
+        . = ALIGN(32);
+        __uninitialized_start = .;
+        *(.uninitialized)
+        KEEP(*(.keep.uninitialized))
+        . = ALIGN(32);
+        __uninitialized_end = .;
+    } > RAM
+
     .bss (NOLOAD):
     {
         . = ALIGN(4);


### PR DESCRIPTION
This section is not touched by the C/C++ library and can hence be used:
- to keep data across soft reboots
- to keep data before and after C/C++ library calls (for example in HAL initialization)

It should be backed up by a compiler-polyfill attribute

@0xc0170 @bremoran @meriac 
