### PR TITLE
Added uVisor-supported config flag

### DIFF
--- a/target.json
+++ b/target.json
@@ -44,6 +44,9 @@
         "user_irq_number": 91
       }
     },
+    "uvisor": {
+      "present": 1
+    },
     "hardware": {
       "externalClock": "8000000",
       "pins": {


### PR DESCRIPTION
The flag means uVisor is supported on the target, not that it is enabled.

@bogdanm 
@meriac 