### PR TITLE
Config: Choose new serial pin pair as C12/F6.

### DIFF
--- a/target.json
+++ b/target.json
@@ -79,8 +79,8 @@
           "scl": "I2C_SCL"
         },
         "serial": {
-          "tx": "SERIAL_TX",
-          "rx": "SERIAL_RX"
+          "tx": "PC_12",
+          "rx": "PF_6"
         }
       }
     }


### PR DESCRIPTION
These are not internally connected to any on-board component.

This is required for unit-testing, since I obviously cannot test the asynchronous serial connection on the same port that I am outputting the unit-test results.

@bremoran @0xc0170 @bogdanm 