### PR TITLE
Add no-inherit tag.

### DIFF
--- a/target.json
+++ b/target.json
@@ -32,7 +32,9 @@
     "cortex-m4",
     "armv7-m",
     "arm",
-    "gcc"
+    "gcc",
+    "stm32f429xi-no-inherit",
+    "stm32f429zi-no-inherit"
   ],
   "config": {
     "mbed-os": {},


### PR DESCRIPTION
This add a `<chip>-no-inherit` tag to `similarTo` to ensure future compatibility with target inheritance.

This feature does not change anything now, but will allow to selectively choose the target dependencies of `mbed-hal-stm32f4` and `cmsis-core-stm32f4` in the future.

@bogdanm @bremoran @0xc0170 @mjs-arm 